### PR TITLE
feat: allow scan/search by org member accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Output is supported in multiple formats: json, table, and csv.
 
 ## Prerequisites
 
-- [Go](https://golang.org/doc/install)
 - Configured AWS credentials
 - Set `export AWS_SDK_LOAD_CONFIG=1` in your shell profile
 
@@ -23,6 +22,9 @@ Flags:
   --profile=default ...  AWS profiles, reusable to add more profiles
   --all-profiles         Use all profiles in ~/.aws/config
   --format=table         Output format, json, table or csv
+  --org                  Scan all organization member accounts
+  --role-name="OrganizationAccountAccessRole"  
+                         Role name to assume in organization member accounts
 
 Commands:
   help [<command>...]
@@ -50,6 +52,23 @@ ratkiez scan --profile aws-profile-eu-central-1 --profile aws-profile-us-west-2 
 
 ```
 
+### Scan An Organization Profile with Multiple Accounts
+```bash
+# Scan all users in all member accounts of an organization
+ratkiez scan --profile aws-org-profile --org --format table
+
+# Scan all users in all member accounts of an organization with custom role name
+ratkiez scan --profile aws-org-profile --org --role-name OrganizationAccountAccessRole --format table
+```
+Sample output:
+```
+USERNAME                                KEY-ID                  CREATION-DATE                    LAST-USED-DATE                 POLICIES                               PROFILE                    ACCOUNT_NAME                   ACCOUNT_ID
+example-lambda-user                     AKIASWXXXXXXXXXXXX      2021-02-15 10:53:57 +0000 UTC    Never Used                     AWSLambda_FullAccess                   org-management-account     management-account             123456789014
+xxxxx-sns-user                          AKIASWXXXXXXXXXXXX      2021-02-15 10:53:57 +0000 UTC    Never Used                     AWSLambda_FullAccess                   aws-profile-eu-central-1   member-account-1               123456789012
+s3-controller                           AKIASWXXXXXXXXXXXX      2020-05-15 08:07:18 +0000 UTC    2020-10-15 08:30:00 +0000 UTC  AmazonS3FullAccess                     aws-profile-us-west-2      member-account-2               123456789013
+```
+
+
 ### Scan All Profiles
 ```bash
 # Scan all users in all aws accounts configured in ~/.aws/config
@@ -58,10 +77,10 @@ ratkiez scan --all-profiles --format table
 
 Sample output:
 ```
-USERNAME                                KEY-ID                  CREATION-DATE                    LAST-USED-DATE                 POLICIES                               PROFILE
-xxxxx-sns-user                          AKIASWXXXXXXXXXXXX      2021-02-15 10:53:57 +0000 UTC    Never Used                     Access_Extension_Lambda                aws-profile-eu-central-1
+USERNAME                                KEY-ID                  CREATION-DATE                    LAST-USED-DATE                 POLICIES                               PROFILE                    ACCOUNT_NAME                   ACCOUNT_ID
+xxxxx-sns-user                          AKIASWXXXXXXXXXXXX      2021-02-15 10:53:57 +0000 UTC    Never Used                     AWSLambda_FullAccess                   aws-profile-eu-central-1
 s3-controller                           AKIASWXXXXXXXXXXXX      2020-05-15 08:07:18 +0000 UTC    2020-10-15 08:30:00 +0000 UTC  AmazonS3FullAccess                     aws-profile-us-west-2
-example-lambda-user                     AKIASWXXXXXXXXXXXX      2021-02-15 10:53:57 +0000 UTC    Never Used                     Access_Extension_Lambda                aws-profile-us-west-2
+example-lambda-user                     AKIASWXXXXXXXXXXXX      2021-02-15 10:53:57 +0000 UTC    Never Used                     AWSLambda_FullAccess                   aws-profile-us-west-2
 ```
 
 ### Look Up Specific User
@@ -89,6 +108,9 @@ ratkiez key AKIASWXXXXXXXXXXXXXX AKIASWXXXXXXXXXXXXXX --all-profiles --format js
 Download the binary from the [releases](https://github.com/rootsami/ratkiez/releases)
 
 ### Build from source
+
+Prerequisites:
+- [Go](https://golang.org/doc/install)
 
 ```bash
 

--- a/internal/aws/cmds.go
+++ b/internal/aws/cmds.go
@@ -2,8 +2,60 @@
 package aws
 
 import (
+	"fmt"
 	"ratkiez/internal/types"
+	"sync"
+
+	"golang.org/x/sync/errgroup"
 )
+
+// ExecuteCommand executes the specified command across all clients
+func ExecuteCommand(cmd string, clients []*Client, config *CommandConfig) (types.KeyDetailsSlice, error) {
+	var (
+		allData types.KeyDetailsSlice
+		mu      sync.Mutex
+		g       errgroup.Group
+	)
+
+	for _, c := range clients {
+		g.Go(func() error {
+			data, err := c.executeCommand(cmd, config)
+			if err != nil {
+				return fmt.Errorf("profile %s: %w", c.profile, err)
+			}
+
+			mu.Lock()
+			allData = append(allData, data...)
+			mu.Unlock()
+
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	if len(allData) == 0 {
+		return nil, fmt.Errorf("no data collected from any profile")
+	}
+
+	return allData, nil
+}
+
+// executeCommand handles command execution for a single client
+func (c *Client) executeCommand(cmd string, config *CommandConfig) (types.KeyDetailsSlice, error) {
+	switch cmd {
+	case config.ScanCmd:
+		return c.scanCommand()
+	case config.UserCmd:
+		return c.userCommand(config.UserList)
+	case config.KeyCmd:
+		return c.keyCommand(config.KeyList)
+	default:
+		return nil, fmt.Errorf("unknown command: %s", cmd)
+	}
+}
 
 func (c *Client) scanCommand() (types.KeyDetailsSlice, error) {
 	users, err := c.listUsers()

--- a/internal/aws/organizations.go
+++ b/internal/aws/organizations.go
@@ -1,0 +1,135 @@
+// internal/aws/organizations.go
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/organizations"
+	"github.com/aws/aws-sdk-go/service/sts"
+)
+
+type AccountInfo struct {
+	ID   string
+	Name string
+}
+
+func (c *Client) getOrganizationAccounts() ([]AccountInfo, error) {
+	if c.session == nil {
+		return nil, fmt.Errorf("invalid session")
+	}
+
+	orgsSvc := organizations.New(c.session)
+
+	// First, get the management account ID to skip the role assumption
+	describeOrg, err := orgsSvc.DescribeOrganization(&organizations.DescribeOrganizationInput{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to describe organization: %v", err)
+	}
+	managementAccountID := *describeOrg.Organization.MasterAccountId
+
+	var accounts []AccountInfo
+	input := &organizations.ListAccountsInput{}
+
+	err = orgsSvc.ListAccountsPages(input, func(page *organizations.ListAccountsOutput, lastPage bool) bool {
+		for _, account := range page.Accounts {
+			// Skip the management account
+			if *account.Id == managementAccountID {
+				continue
+			}
+
+			if account.Id != nil && account.Name != nil {
+				accounts = append(accounts, AccountInfo{
+					ID:   *account.Id,
+					Name: *account.Name,
+				})
+			}
+		}
+		return !lastPage
+	})
+
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == organizations.ErrCodeAWSOrganizationsNotInUseException {
+				return nil, fmt.Errorf("AWS Organizations is not enabled for this account")
+			}
+		}
+		return nil, fmt.Errorf("failed to list organization accounts: %v", err)
+	}
+
+	if len(accounts) == 0 {
+		return nil, fmt.Errorf("no member accounts found in the organization")
+	}
+
+	return accounts, nil
+}
+
+// assumeRole assumes the specified role in a target account and returns a new session
+func (c *Client) assumeRole(accountID, roleName string) (*session.Session, error) {
+	if c.session == nil {
+		return nil, fmt.Errorf("invalid session")
+	}
+
+	stsSvc := sts.New(c.session)
+
+	roleARN := fmt.Sprintf("arn:aws:iam::%s:role/%s", accountID, roleName)
+	sessionName := fmt.Sprintf("RatkiezScan-%s", c.profile)
+
+	result, err := stsSvc.AssumeRole(&sts.AssumeRoleInput{
+		RoleArn:         aws.String(roleARN),
+		RoleSessionName: aws.String(sessionName),
+		DurationSeconds: aws.Int64(900), // 15 minutes
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to assume role in account %s: %v", accountID, err)
+	}
+
+	// Create a new session with the assumed role credentials
+	return session.NewSession(&aws.Config{
+		Credentials: credentials.NewStaticCredentials(
+			*result.Credentials.AccessKeyId,
+			*result.Credentials.SecretAccessKey,
+			*result.Credentials.SessionToken,
+		),
+		Region: c.session.Config.Region,
+	})
+}
+
+// createMemberAccountClients creates IAM clients for all member accounts
+func (c *Client) createMemberAccountClients(roleName string) ([]*Client, error) {
+	if c.session == nil {
+		return nil, fmt.Errorf("invalid session")
+	}
+
+	accounts, err := c.getOrganizationAccounts()
+	if err != nil {
+		return nil, err
+	}
+
+	var clients []*Client
+	for _, account := range accounts {
+		sess, err := c.assumeRole(account.ID, roleName)
+		if err != nil {
+			fmt.Printf("Warning: Failed to assume role in account %s (%s): %v\n", account.Name, account.ID, err)
+			continue
+		}
+
+		clients = append(clients, &Client{
+			session:     sess,
+			iam:         iam.New(sess),
+			profile:     fmt.Sprintf("member-of-%s", c.profile),
+			accountID:   account.ID,
+			accountName: account.Name,
+		})
+	}
+
+	if len(clients) == 0 {
+		return nil, fmt.Errorf("no member account clients could be created")
+	}
+
+	return clients, nil
+}

--- a/internal/aws/profiles.go
+++ b/internal/aws/profiles.go
@@ -1,0 +1,48 @@
+package aws
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/ini.v1"
+)
+
+// GetProfiles returns list of AWS profiles to use
+func GetProfiles(useAllProfiles bool, specifiedProfiles []string) ([]string, error) {
+	if useAllProfiles {
+		return getAllProfiles()
+	}
+	return specifiedProfiles, nil
+}
+
+// TODO: make aws config path configurable
+// getAllProfiles reads all profiles from AWS config
+func getAllProfiles() ([]string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("unable to get home directory: %v", err)
+	}
+
+	configPath := filepath.Join(homeDir, ".aws", "config")
+	cfg, err := ini.Load(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to load AWS config file: %v", err)
+	}
+
+	var profiles []string
+	for _, section := range cfg.Sections() {
+		name := section.Name()
+		if name == "default" {
+			profiles = append(profiles, "default")
+		} else if strings.HasPrefix(name, "profile ") {
+			profiles = append(profiles, strings.TrimPrefix(name, "profile "))
+		}
+	}
+
+	if len(profiles) == 0 {
+		return nil, fmt.Errorf("no AWS profiles found")
+	}
+	return profiles, nil
+}

--- a/internal/aws/scan.go
+++ b/internal/aws/scan.go
@@ -63,6 +63,8 @@ func (c *Client) getUserDetails(user *iam.User) (types.KeyDetailsSlice, error) {
 			LastUsedDate: "N/A",
 			Policies:     policies,
 			Profile:      c.profile,
+			AccountID:    c.accountID,
+			AccountName:  c.accountName,
 		})
 		return details, nil
 	}
@@ -80,6 +82,8 @@ func (c *Client) getUserDetails(user *iam.User) (types.KeyDetailsSlice, error) {
 			LastUsedDate: lastUsed,
 			Policies:     policies,
 			Profile:      c.profile,
+			AccountID:    c.accountID,
+			AccountName:  c.accountName,
 		})
 	}
 

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -39,7 +39,7 @@ func (f *Formatter) Print(data types.KeyDetailsSlice) error {
 }
 
 func (f *Formatter) printTable(data types.KeyDetailsSlice) error {
-	headers := []string{"USERNAME", "KEY-ID", "CREATION-DATE", "LAST-USED-DATE", "POLICIES", "PROFILE"}
+	headers := []string{"USERNAME", "KEY-ID", "CREATION-DATE", "LAST-USED-DATE", "POLICIES", "PROFILE", "ACCOUNT-NAME", "ACCOUNT-ID"}
 	var rows [][]string
 
 	for _, v := range data {
@@ -50,6 +50,8 @@ func (f *Formatter) printTable(data types.KeyDetailsSlice) error {
 			v.LastUsedDate,
 			strings.Join(v.Policies, ", "),
 			v.Profile,
+			v.AccountName,
+			v.AccountID,
 		})
 	}
 
@@ -84,7 +86,7 @@ func (f *Formatter) printJSON(data types.KeyDetailsSlice) error {
 func (f *Formatter) printCSV(data types.KeyDetailsSlice) error {
 
 	// Write headers
-	headers := []string{"USERNAME", "KEY-ID", "CREATION-DATE", "LAST-USED-DATE", "POLICIES", "PROFILE"}
+	headers := []string{"USERNAME", "KEY-ID", "CREATION-DATE", "LAST-USED-DATE", "POLICIES", "PROFILE", "ACCOUNT-NAME", "ACCOUNT-ID"}
 	fmt.Println(strings.Join(headers, ","))
 
 	// Write data
@@ -96,6 +98,8 @@ func (f *Formatter) printCSV(data types.KeyDetailsSlice) error {
 			v.LastUsedDate,
 			strings.Join(v.Policies, "; "),
 			v.Profile,
+			v.AccountName,
+			v.AccountID,
 		}
 		fmt.Println(strings.Join(record, ","))
 	}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -8,6 +8,8 @@ type KeyDetails struct {
 	LastUsedDate string   `json:"last_used_date"`
 	Policies     []string `json:"policies"`
 	Profile      string   `json:"profile"`
+	AccountID    string   `json:"account_id"`
+	AccountName  string   `json:"account_name"`
 }
 
 type KeyDetailsSlice []KeyDetails


### PR DESCRIPTION
Enhancements to command-line interface:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R25-R27): Added `--org` and `--role-name` flags to scan all organization member accounts and assume a specified role, respectively.
* [`cmd/ratkiez/main.go`](diffhunk://#diff-16755bda972e222ecbbeae95c522121af5360d90177ed75b1d33b29d1f6f570dR23-R24): Introduced new flags `--org` and `--role-name`, and added validation to prevent using `--all-profiles` and `--org` flags together. [[1]](diffhunk://#diff-16755bda972e222ecbbeae95c522121af5360d90177ed75b1d33b29d1f6f570dR23-R24) [[2]](diffhunk://#diff-16755bda972e222ecbbeae95c522121af5360d90177ed75b1d33b29d1f6f570dR57-R67)

Client creation and organization account handling:

* [`internal/aws/clients.go`](diffhunk://#diff-c0dbe684d9414da90140aa8b636ed5560ee2cc30b7b46781aa5bfc876620ba8cR20-R60): Updated `NewClients` function to support creating clients for organization member accounts when the `--org` flag is set.
* [`internal/aws/organizations.go`](diffhunk://#diff-e2e415f1d68e7e6f6d37efe6bf6610837b26b33f57572aa9009da811e139b43dR1-R135): Added new functions to retrieve organization accounts and assume roles in member accounts.

Output formatting improvements:

* [`internal/output/output.go`](diffhunk://#diff-eebedd806b03df3ddd8289c090576c3f605e67ee65f6f71344d21b42d4b79b1cL42-R42): Enhanced table and CSV output formats to include `ACCOUNT-NAME` and `ACCOUNT-ID` columns. [[1]](diffhunk://#diff-eebedd806b03df3ddd8289c090576c3f605e67ee65f6f71344d21b42d4b79b1cL42-R42) [[2]](diffhunk://#diff-eebedd806b03df3ddd8289c090576c3f605e67ee65f6f71344d21b42d4b79b1cL87-R89)
* [`internal/types/types.go`](diffhunk://#diff-f81c847945df70ba0419b7266b8aeb8e2a4c1d9385bfb8b60c9ea750985d73a8R11-R12): Updated `KeyDetails` struct to include `AccountID` and `AccountName` fields.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R55-R71): Added examples and sample outputs for scanning organization profiles with the new flags. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R55-R71) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L61-R83)
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9): Moved the Go installation instruction to the "Build from source" section. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R112-R114)